### PR TITLE
fix: allow safe writes in a GET query and user correct permission.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow safe writes in for the sitemap.xml.gz request
+  [erral]
 
 
 1.1.0 (2024-03-23)

--- a/src/collective/splitsitemap/browser/configure.zcml
+++ b/src/collective/splitsitemap/browser/configure.zcml
@@ -30,7 +30,7 @@
     name="sitemap.xml.gz"
     for="plone.app.layout.navigation.interfaces.INavigationRoot"
     class=".sitemap.SiteMapView"
-    permission="zope2.Public"
+    permission="zope.Public"
     layer="collective.splitsitemap.interfaces.ICollectiveSplitsitemapLayer"
     />
 

--- a/src/collective/splitsitemap/browser/sitemap.py
+++ b/src/collective/splitsitemap/browser/sitemap.py
@@ -5,6 +5,7 @@ from collective.splitsitemap.interfaces import ISplitSitemapSettings
 from gzip import GzipFile
 from persistent.mapping import PersistentMapping
 from plone.memoize import ram
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
@@ -14,6 +15,7 @@ from six import BytesIO
 from time import time
 from zope.annotation import IAnnotations
 from zope.component import getUtility
+from zope.interface import alsoProvides
 from zope.publisher.interfaces import NotFound
 
 import logging
@@ -195,6 +197,8 @@ class SiteMapView(BrowserView):
 
     def _generate(self, items=None):
         """Generates the Gzipped sitemap."""
+        alsoProvides(self.request, IDisableCSRFProtection)
+
         results = ""
         ctx_path = "/".join(self.context.getPhysicalPath())
         logger.info("Generating sitemap.xml.gz for %s" % ctx_path)


### PR DESCRIPTION
- Calling `sitemap.xml.gz` may need to write in the database because it creates static `sitemap%s.xml.gz` files, so we need to disable the CSRF protection for this GET request.
- Use `zope.Public` as permission
- Use `adopt_roles` to be able to create and delete the sitemap files in the ZMI